### PR TITLE
fix: update badge to use PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add JSON schema for Zuul CI config files
 - Add JSON schema for ansible-lint config files
 - Add JSON schema for molecule scenarios
+- Fix badge urls for marketplace
 
 ## 0.1.0
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
      "url": "https://vsmarketplacebadge.apphb.com/version/zbr.vscode-ansible.svg",
      "href": "https://marketplace.visualstudio.com/items?itemName=zbr.vscode-ansible"},
     {"description": "CI/CD Pipeline",
-     "url": "https://github.com/ansible-community/vscode-ansible/actions/workflows/release.yaml/badge.svg",
-     "href": "https://github.com/ansible-community/vscode-ansible/actions/workflows/release.yaml"}
+     "url": "https://img.shields.io/github/workflow/status/ansible-community/vscode-ansible/ci.png",
+     "href": "https://github.com/ansible-community/vscode-ansible/actions/workflows/ci.yaml"}
   ],
   "displayName": "Ansible Language",
   "description": "Ansible YAML schema verification, auto-complete, highlight problems reported by ansible-lint, yamllint.",


### PR DESCRIPTION
Marketplace does not allow SVG and Github Actions can only produce
SVG ones, so we rely on 3rd parties to build compatible ones.