### PR TITLE
Add an explicit extension dependency on vscode-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,9 +167,6 @@
       "name": "Sorin Sbarnea"
     }
   ],
-  "extensionDependencies": [
-    "redhat.vscode-yaml"
-  ],
   "dependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
@@ -195,6 +192,9 @@
   "engines": {
     "vscode": "^1.53.0"
   },
+  "extensionDependencies": [
+    "redhat.vscode-yaml"
+  ],
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"

--- a/package.json
+++ b/package.json
@@ -167,6 +167,9 @@
       "name": "Sorin Sbarnea"
     }
   ],
+  "extensionDependencies": [
+    "redhat.vscode-yaml"
+  ],
   "dependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",


### PR DESCRIPTION
This PR adds an explicit extension dependency on vscode-yaml. This makes it so that when you are installing this extension, if vscode-yaml is not already installed then it will automatically install it

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>