### PR TITLE
Fix typo in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.3.0
 
 - Added file associations for common files found on Ansible and Python repos
-- Added schema verification for galaxy.tml files
+- Added schema verification for galaxy.yml files
 
 ## 0.2.0
 


### PR DESCRIPTION
`galaxy.yml` -> `galaxy.yml`