### PR TITLE
fix: advertise Microsoft Python extension as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "vscode": "^1.53.0"
   },
   "extensionDependencies": [
+    "ms-python.python",
     "redhat.vscode-yaml"
   ],
   "husky": {


### PR DESCRIPTION
As Ansible content is high-likely to contain Python code and
because we need to make use of pip to install our linter, it is
better to advertise the Python extension as a dependency.