### PR TITLE
Match found problems to source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --max-warnings 0 --ext ts",
     "pretest": "npm run compile && npm run lint",
     "test": "node ./out/test/runTest.js",
     "vscode:prepublish": "npm run compile",

--- a/src/features/validationProvider.ts
+++ b/src/features/validationProvider.ts
@@ -247,7 +247,7 @@ export default class AnsibleValidationProvider {
 				if (matches) {
 					let message = matches.groups?.message ?? "unknown";
 					let line = parseInt(matches.groups?.line ?? "1") - 1;
-					let file = this.determineMatchFile(matches.groups?.file, textDocument)
+					let file = this.determineMatchFile(matches.groups?.file, textDocument);
 					let severity = matches.groups?.severity;
 					let diagnostic: vscode.Diagnostic = new vscode.Diagnostic(
 						new vscode.Range(line, 0, line, Number.MAX_VALUE),
@@ -255,7 +255,7 @@ export default class AnsibleValidationProvider {
             			this.ansibleLintSeverityToVSCodeDiagnosticsSeverity(severity)
 					);
 					if (diagnostics[file.toString()] === undefined) {
-						diagnostics[file.toString()] = []
+						diagnostics[file.toString()] = [];
 					}
 					diagnostics[file.toString()].push(diagnostic);
 				}
@@ -327,7 +327,7 @@ export default class AnsibleValidationProvider {
 				return vscode.DiagnosticSeverity.Error;
 		}
   }
-    
+
 	private determineMatchFile(matchFile: string|undefined, sourceDocument: vscode.TextDocument): vscode.Uri {
 		if (matchFile === undefined || vscode.workspace.workspaceFolders === undefined) {
 			return sourceDocument.uri;

--- a/src/features/validationProvider.ts
+++ b/src/features/validationProvider.ts
@@ -80,6 +80,10 @@ namespace RunTrigger {
 	};
 }
 
+interface DiagnosticsDictionary {
+	[key: string]: vscode.Diagnostic[];
+}
+
 export default class AnsibleValidationProvider {
 
 	private static matchExpression: RegExp = /^(?<file>[^:]+):(?<line>\d+):(?<column>:(\d):)? (?<id>[\w-]+) (?<message>.*)/;
@@ -236,18 +240,22 @@ export default class AnsibleValidationProvider {
 		return new Promise<void>((resolve) => {
 			let executable = this.executable || 'ansible-lint';
 			let decoder = new LineDecoder();
-			let diagnostics: vscode.Diagnostic[] = [];
+			let diagnostics: DiagnosticsDictionary = {};
 			let processLine = (line: string) => {
 				let matches = line.match(AnsibleValidationProvider.matchExpression);
 				this.output.appendLine(`Found:\n${matches}`);
 				if (matches) {
 					let message = matches.groups?.message ?? "unknown";
 					let line = parseInt(matches.groups?.line ?? "1") - 1;
+					let file = this.determineMatchFile(matches.groups?.file, textDocument)
 					let diagnostic: vscode.Diagnostic = new vscode.Diagnostic(
 						new vscode.Range(line, 0, line, Number.MAX_VALUE),
 						message
 					);
-					diagnostics.push(diagnostic);
+					if (diagnostics[file.toString()] === undefined) {
+						diagnostics[file.toString()] = []
+					}
+					diagnostics[file.toString()].push(diagnostic);
 				}
 			};
 
@@ -284,7 +292,9 @@ export default class AnsibleValidationProvider {
 						if (line) {
 							processLine(line);
 						}
-						this.diagnosticCollection!.set(textDocument.uri, diagnostics);
+						for (let key in diagnostics) {
+							this.diagnosticCollection!.set(vscode.Uri.parse(key), diagnostics[key]);
+						}
 						resolve();
 					});
 				} else {
@@ -295,6 +305,14 @@ export default class AnsibleValidationProvider {
 				this.showError(error, executable);
 			}
 		});
+	}
+
+	private determineMatchFile(matchFile: string|undefined, sourceDocument: vscode.TextDocument): vscode.Uri {
+		if (matchFile === undefined || vscode.workspace.workspaceFolders === undefined) {
+			return sourceDocument.uri;
+		}
+
+		return vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri,matchFile);
 	}
 
 	private async showError(error: any, executable: string): Promise<void> {


### PR DESCRIPTION
When running ansible-lint on a playbook, all referenced files are checked for problems as well. The extension listed all those problems as originating in the playbook file nevertheless.
This PR matches all reported problems to their correct source file and forwards the problems to VSCode diagnostics sorted by file.

Originally proposed by @FloSchwalm on #69