### PR TITLE
build: replace use of pre-commit.ci with github action

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,11 +9,11 @@
   ],
   "root": true,
   "rules": {
-    "@typescript-eslint/naming-convention": "warn",
-    "@typescript-eslint/semi": "warn",
-    "curly": "warn",
-    "eqeqeq": "warn",
-    "no-throw-literal": "warn",
+    "@typescript-eslint/naming-convention": "error",
+    "@typescript-eslint/semi": "error",
+    "curly": "error",
+    "eqeqeq": "error",
+    "no-throw-literal": "error",
     "semi": "off"
   }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+
   build:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -25,17 +25,18 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Set up Node
-      - name: Use Node 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - name: Use Node
+        uses: actions/setup-node@v2
 
       # Run install dependencies
       - name: Install dependencies
         run: |
-          npm config set fund false --global
+          pipx install pre-commit
+          npm config set fund false
           npm install
+
+      - name: Run lint
+        run: npm run-script lint
 
       # Build extension
       - name: Run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
   - id: check-merge-conflict
   - id: check-json
   - id: pretty-format-json
+    exclude: >
+      (?x)^(
+        package-lock.json
+      )$
     args: ['--autofix']
   - id: debug-statements
     language_version: python3

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
-    "lint": "eslint src --max-warnings 0 --ext ts",
+    "lint": "pre-commit run -a",
     "pretest": "npm run compile && npm run lint",
     "test": "node ./out/test/runTest.js",
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Replace use of pre-commit.ci with our own action due in order to avoid its limitations (unable to run eslint due to security model involved)

Related: https://github.com/pre-commit-ci/issues/issues/55