### PR TITLE
build: replace use of pre-commit.ci with github action

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,11 +9,11 @@
   ],
   "root": true,
   "rules": {
-    "@typescript-eslint/naming-convention": "warn",
-    "@typescript-eslint/semi": "warn",
-    "curly": "warn",
-    "eqeqeq": "warn",
-    "no-throw-literal": "warn",
+    "@typescript-eslint/naming-convention": "error",
+    "@typescript-eslint/semi": "error",
+    "curly": "error",
+    "eqeqeq": "error",
+    "no-throw-literal": "error",
     "semi": "off"
   }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,16 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  lint:
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node 12
+        uses: actions/setup-node@v2
+
+      - name: Run linting
+        run: npm run-script lint
+
   build:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -25,11 +34,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Set up Node
-      - name: Use Node 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - name: Use Node
+        uses: actions/setup-node@v2
 
       # Run install dependencies
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
-    "lint": "eslint src --max-warnings 0 --ext ts",
+    "lint": "pre-commit run -a",
     "pretest": "npm run compile && npm run lint",
     "test": "node ./out/test/runTest.js",
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Replace use of pre-commit.ci with our own action due in order to
avoid its limitations.

Related: https://github.com/pre-commit-ci/issues/issues/55