### PR TITLE
fix: correct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * ...
 
-## 0.4.1
+## 0.4.2
 
 * Reduce minimal version of vscode that is required (#90) @ssbarnea
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/node": "^15.0.2",
-        "@types/vscode": "^1.56.0",
+        "@types/vscode": "^1.53.0",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
         "eslint": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.0.2",
-    "@types/vscode": "^1.56.0",
+    "@types/vscode": "^1.53.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "eslint": "^7.26.0",


### PR DESCRIPTION
Previous release failed to publish as vscode types were newer than the required vscode.