### PR TITLE
fix: lower version of vscode required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/node": "^15.0.2",
-        "@types/vscode": "^1.52.0",
+        "@types/vscode": "^1.50.0",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
         "eslint": "^7.26.0",
@@ -36,7 +36,7 @@
       "engines": {
         "node": ">=16.0",
         "npm": "^7.12.1",
-        "vscode": "^1.52.0",
+        "vscode": "^1.50.0",
         "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"
       }
     },

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.0.2",
-    "@types/vscode": "^1.52.0",
+    "@types/vscode": "^1.50.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "eslint": "^7.26.0",
@@ -239,7 +239,7 @@
   "engines": {
     "node": ">=16.0",
     "npm": "^7.12.1",
-    "vscode": "^1.52.0",
+    "vscode": "^1.50.0",
     "yarn": "\n\nERROR: Please use npm, yarn is not supported in this repository!!!\n\n"
   },
   "extensionDependencies": [


### PR DESCRIPTION
To keep extension compatible with Eclipse Theia, we lower
the version of vscode engine we require.

Related: https://github.com/eclipse-theia/theia-blueprint/issues/96