### PR TITLE
chore: run commitlint on pr title

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,11 +1,13 @@
-name: Lint Commit Messages
-on: [pull_request]
+name: commitlint
+on:
+  pull_request:
+    types: ["opened", "edited", "reopened", "synchronize"]
 
 jobs:
-  commitlint:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v3
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: npm install @commitlint/config-conventional
+      - uses: JulienKode/pull-request-name-linter-action@v0.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 ---
+ci:
+  # format compatible with commitlint
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    chore: auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: v4.0.1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "extends": [
     "@commitlint/config-conventional"
   ]


### PR DESCRIPTION
Makes it easier to use consistent commit messages by checking PR title, which can easily be fix by either the author or a core
developer. When we do the squash commit, this end-up as commit message, one that will be commitlint compliant.

Previous action was only checking the commit itself, so it would have being fixable by only making a new forced push to the pull-request branch.